### PR TITLE
sama{5/7}.inc: convert to new override syntax

### DIFF
--- a/conf/machine/include/sama5.inc
+++ b/conf/machine/include/sama5.inc
@@ -5,9 +5,9 @@ require conf/machine/include/bootloaders.inc
 
 SOC_FAMILY = "sama5"
 
-PREFERRED_PROVIDER_virtual/kernel_sama5 ?= "linux-at91"
-PREFERRED_PROVIDER_virtual/bootloader_sama5 ?= "u-boot-at91"
-PREFERRED_PROVIDER_u-boot_sama5 ?= "u-boot-at91"
+PREFERRED_PROVIDER_virtual/kernel:sama5 ?= "linux-at91"
+PREFERRED_PROVIDER_virtual/bootloader:sama5 ?= "u-boot-at91"
+PREFERRED_PROVIDER_u-boot:sama5 ?= "u-boot-at91"
 
 PREFERRED_PROVIDER_jpeg ?= "jpeg"
 PREFERRED_PROVIDER_jpeg-native ?= "jpeg-native"

--- a/conf/machine/include/sama7.inc
+++ b/conf/machine/include/sama7.inc
@@ -5,9 +5,9 @@ require conf/machine/include/bootloaders.inc
 
 SOC_FAMILY = "sama7"
 
-PREFERRED_PROVIDER_virtual/kernel_sama7 ?= "linux-at91"
-PREFERRED_PROVIDER_virtual/bootloader_sama7 ?= "u-boot-at91"
-PREFERRED_PROVIDER_u-boot_sama7 ?= "u-boot-at91"
+PREFERRED_PROVIDER_virtual/kernel:sama7 ?= "linux-at91"
+PREFERRED_PROVIDER_virtual/bootloader:sama7 ?= "u-boot-at91"
+PREFERRED_PROVIDER_u-boot:sama7 ?= "u-boot-at91"
 
 PREFERRED_PROVIDER_jpeg ?= "jpeg"
 PREFERRED_PROVIDER_jpeg-native ?= "jpeg-native"


### PR DESCRIPTION
Fixes:

ERROR: Multiple .bb files are due to be built which each provide u-boot:########################                                                                                             | ETA:  0:00:02
  /work/poky/meta/recipes-bsp/u-boot/u-boot_2021.07.bb
  /work/meta-atmel/recipes-bsp/u-boot/u-boot-at91_2020.01.bb
A list of tasks depending on these providers is shown and may help explain where the dependency comes from.
/work/poky/meta/recipes-bsp/u-boot/u-boot_2021.07.bb has unique dependees:
  /work/poky/meta/recipes-core/images/core-image-base.bb:do_image_complete
/work/meta-atmel/recipes-bsp/u-boot/u-boot-at91_2020.01.bb has unique dependees:
  /work/poky/meta/recipes-core/images/core-image-base.bb:do_image_wic
It could be that one recipe provides something the other doesn't and should. The following provider and runtime provider differences may be helpful.
/work/poky/meta/recipes-bsp/u-boot/u-boot_2021.07.bb has unique provides:

/work/poky/meta/recipes-bsp/u-boot/u-boot_2021.07.bb has unique rprovides:
  ^u-boot-locale-.*

Signed-off-by: Pierre-Jean Texier <texier.pj2@gmail.com>